### PR TITLE
Do math on integers, then convert to float.  Do not work with floats …

### DIFF
--- a/polet/src/main/java/com/fievx/polet/drawingDecoration/LineDrawingDecoration.kt
+++ b/polet/src/main/java/com/fievx/polet/drawingDecoration/LineDrawingDecoration.kt
@@ -21,28 +21,28 @@ class LineDrawingDecoration (@ColorInt color: Int, val position: Position, val t
     override fun onDraw(rect: Rect, view: View, c: Canvas, parent: RecyclerView, state: RecyclerView.State) {
         when (position){
             Position.top ->
-                c.drawRect(view.left - rect.left.toFloat(),
-                    view.top - rect.top.toFloat(),
-                    view.right + rect.right.toFloat(),
-                    view.top - rect.top.toFloat() + thickness.toFloat(),
+                c.drawRect((view.left - rect.left).toFloat(),
+                    (view.top - rect.top).toFloat(),
+                    (view.right + rect.right).toFloat(),
+                    (view.top - rect.top + thickness.toFloat()).toFloat(),
                     paint)
             Position.bottom ->
-                c.drawRect(view.left - rect.left.toFloat(),
-                    view.bottom + rect.bottom.toFloat() - thickness.toFloat(),
-                    view.right + rect.right.toFloat(),
-                    view.bottom + rect.bottom.toFloat(),
+                c.drawRect((view.left - rect.left).toFloat(),
+                    (view.bottom + rect.bottom - thickness).toFloat(),
+                    (view.right + rect.right).toFloat(),
+                    (view.bottom + rect.bottom).toFloat(),
                     paint)
             Position.left ->
-                c.drawRect(view.left - rect.left.toFloat(),
-                    view.top - rect.top.toFloat(),
-                    view.left - rect.left.toFloat() + thickness.toFloat(),
-                    view.bottom + rect.bottom.toFloat(),
+                c.drawRect((view.left - rect.left).toFloat(),
+                    (view.top - rect.top).toFloat(),
+                    (view.left - rect.left + thickness).toFloat(),
+                    (view.bottom + rect.bottom).toFloat(),
                     paint)
             Position.right ->
-                c.drawRect(view.right + rect.right.toFloat() - thickness.toFloat(),
-                    view.top - rect.top.toFloat(),
-                    view.right + rect.right.toFloat(),
-                    view.bottom + rect.bottom.toFloat(),
+                c.drawRect((view.right + rect.right - thickness).toFloat(),
+                    (view.top - rect.top).toFloat(),
+                    (view.right + rect.right).toFloat(),
+                    (view.bottom + rect.bottom).toFloat(),
                     paint)
         }
     }
@@ -55,3 +55,5 @@ class LineDrawingDecoration (@ColorInt color: Int, val position: Position, val t
     }
 
 }
+
+fun sumToFloat(vararg nums: Int): Float = nums.sum().toFloat()

--- a/polet/src/main/java/com/fievx/polet/drawingDecoration/LineDrawingDecoration.kt
+++ b/polet/src/main/java/com/fievx/polet/drawingDecoration/LineDrawingDecoration.kt
@@ -55,5 +55,3 @@ class LineDrawingDecoration (@ColorInt color: Int, val position: Position, val t
     }
 
 }
-
-fun sumToFloat(vararg nums: Int): Float = nums.sum().toFloat()

--- a/polet/src/main/java/com/fievx/polet/drawingDecoration/PaintingDecoration.kt
+++ b/polet/src/main/java/com/fievx/polet/drawingDecoration/PaintingDecoration.kt
@@ -15,10 +15,10 @@ class PaintingDecoration(@ColorInt color: Int): DrawingDecoration {
     }
 
     override fun onDraw(rect: Rect, view: View, c: Canvas, parent: RecyclerView, state: RecyclerView.State) {
-        c.drawRect(view.left - rect.left.toFloat(),
-                view.top - rect.top.toFloat(),
-                view.right + rect.right.toFloat(),
-                view.bottom + rect.bottom.toFloat(),
+        c.drawRect((view.left - rect.left).toFloat(),
+            (view.top - rect.top).toFloat(),
+            (view.right + rect.right).toFloat(),
+            (view.bottom + rect.bottom).toFloat(),
                 paint)
     }
 }


### PR DESCRIPTION
…as intermediate values

I noticed a visual bug with the line decorations.  They would be an inconsistent thickness.  The easiest way to replicate this is to create a LineDrawingDecoration of thickness 1 positioned at the bottom.  Sometimes you would not see the decoration.

The issue is that some of the math was operating on floats.  Instead, the math should be done using ints and then converted to a float.